### PR TITLE
feat: make breakpoints compatible with number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,13 @@ import type { Preset } from "unocss"
 import { escapeSelector } from "unocss"
 import { ensureSuffix } from "./utils"
 
-export type Brekpoints = Record<string, string | number>
+export type Breakpoints = Record<string, string | number>
 export interface GridOptions {
   prefix?: string
   piece?: string
   gutter?: string
   columns?: number
-  breakpoints?: Brekpoints
+  breakpoints?: Breakpoints
 }
 
 export function presetGrid(options: GridOptions = {}): Preset {
@@ -38,7 +38,7 @@ export function presetGrid(options: GridOptions = {}): Preset {
         new RegExp(`^__container$`),
         ([], { rawSelector, generator }: any) => {
           const _selector = escapeSelector(rawSelector)
-          const _breakpoints: Brekpoints = generator?.userConfig?.theme?.breakpoints ?? breakpoints
+          const _breakpoints: Breakpoints = generator?.userConfig?.theme?.breakpoints ?? breakpoints
 
           const template = Object.keys(_breakpoints).map(
             (breakpoint) => `@media (min-width: ${ensureSuffix('px', _breakpoints[breakpoint].toString())}) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import type { Preset } from "unocss"
 import { escapeSelector } from "unocss"
+import { ensureSuffix } from "./utils"
 
+export type Brekpoints = Record<string, string | number>
 export interface GridOptions {
   prefix?: string
   piece?: string
   gutter?: string
   columns?: number
-  breakpoints?: Record<string, string>
+  breakpoints?: Brekpoints
 }
 
 export function presetGrid(options: GridOptions = {}): Preset {
@@ -36,12 +38,12 @@ export function presetGrid(options: GridOptions = {}): Preset {
         new RegExp(`^__container$`),
         ([], { rawSelector, generator }: any) => {
           const _selector = escapeSelector(rawSelector)
-          const _breakpoints = generator?.userConfig?.theme?.breakpoints ?? breakpoints
+          const _breakpoints: Brekpoints = generator?.userConfig?.theme?.breakpoints ?? breakpoints
 
           const template = Object.keys(_breakpoints).map(
-            (breakpoint: string) => `@media (min-width: ${_breakpoints[breakpoint]}) {
+            (breakpoint) => `@media (min-width: ${ensureSuffix('px', _breakpoints[breakpoint].toString())}) {
               .${_selector} {
-                max-width: calc(${_breakpoints[breakpoint]} - ${piece});
+                max-width: calc(${ensureSuffix('px', _breakpoints[breakpoint].toString())} - ${piece});
               }
             }`
           )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export function ensureSuffix(suffix: string, str: string) {
+  if (!str.endsWith(suffix))
+    return str + suffix
+  return str
+}


### PR DESCRIPTION
This is an add to make `unocss` imported breakpoints compatible.
For example:
`import { breakpointsTailwind } from '@vueuse/core'` is typed as 
```
const breakpointsTailwind: {
    sm: number;
    md: number;
    lg: number;
    xl: number;
    '2xl': number;
}
```
and this is breaking typescript from `breakpoints?: Record<string, string>`
